### PR TITLE
Clean protocols from remote strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version: 1.14
       - run: go mod download
-      - run: go build .
+      - run: go test
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/tools/go/vcs"
@@ -23,7 +24,7 @@ func main() {
 	}
 	remote := args[0]
 
-	resp, err := download(path, filepath.Clean(remote))
+	resp, err := download(path, clean(remote))
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
@@ -60,6 +61,13 @@ func getPath() (string, error) {
 	}
 
 	return path, nil
+}
+
+// clean cleans up the remote string by treating it as a filepath and removing protocols.
+func clean(remote string) string {
+	r1, _ := regexp.Compile("^[a-zA-Z]*://")
+	r2, _ := regexp.Compile("/{2,}")
+	return r2.ReplaceAllString(r1.ReplaceAllString(remote, ""), "/")
 }
 
 // download clones the remote repository to the GETPATH.

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestClean(t *testing.T) {
+	cases := map[string]struct {
+		remote string
+		want   string
+	}{
+		"git": {
+			remote: "git://github.com/arbourd/git-get",
+			want:   "github.com/arbourd/git-get",
+		},
+		"https": {
+			remote: "https://github.com/arbourd/git-get",
+			want:   "github.com/arbourd/git-get",
+		},
+		"filepath": {
+			remote: "github.com///arbourd/git-get",
+			want:   "github.com/arbourd/git-get",
+		},
+		"https filepath": {
+			remote: "https://github.com///arbourd/git-get",
+			want:   "github.com/arbourd/git-get",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			str := clean(c.remote)
+			if str != c.want {
+				t.Fatalf("unexpected cleaned string:\n\t(GOT): %#v\n\t(WNT): %#v", str, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Removes https:// and git:// from remote urls. This is useful if you
copied from Github.com or another source and forget to manually remove
the protocol. This *does not* handle ssh urls tho.