### PR TITLE
Add SSH protocol support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+      - run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
 
       - run: go mod download
       - run: go test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 `git-get` clones repositories to your `GETPATH` in the same fashion as `go get`.
 
+## Usage
+
+Set a `GETPATH` or use the default of `~/src`.
+
+```shell
+export GETPATH=~/src
+```
+
+Get a repository.
+
+```console
+$ git get github.com/arbourd/git-get
+~/src/github.com/arbourd/git-get
+
+$ git get git@github.com:arbourd/git-get.git
+~/src/github.com/arbourd/git-get
+```
+
+### Using SSH as the default
+
+By default, when getting a repository without specifying a protocol (eg: github.com/arbourd/git-get) HTTPS will be used.
+
+If you would prefer to use SSH or any other protocol, configure your [Git config](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) to redirect.
+
+```console
+$ git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+```
+
 ## Installation
 
 Install with `brew`.
@@ -14,19 +42,4 @@ Install with `go get`.
 
 ```console
 $ go get -u github.com/arbourd/git-get
-```
-
-## Usage
-
-Set a `GETPATH` or use the default of `~/src`.
-
-```console
-$ export GETPATH=~/src
-```
-
-Get a repository.
-
-```console
-$ git get github.com/arbourd/git-get
-~/src/github.com/arbourd/git-get
 ```

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,38 +45,83 @@ func TestGetPath(t *testing.T) {
 	}
 }
 
-func TestClean(t *testing.T) {
+func TestParseURL(t *testing.T) {
 	cases := map[string]struct {
 		remote string
 		want   string
 	}{
 		"git protocol": {
-			remote: "git://github.com/arbourd/git-get",
-			want:   "github.com/arbourd/git-get",
+			remote: "git://github.com/arbourd/git-get.git",
+			want:   "git://github.com/arbourd/git-get.git",
 		},
 		"https protocol": {
-			remote: "https://github.com/arbourd/git-get",
-			want:   "github.com/arbourd/git-get",
+			remote: "https://github.com/arbourd/git-get.git",
+			want:   "https://github.com/arbourd/git-get.git",
 		},
-		".git removal": {
-			remote: "github.com/arbourd/git-get.git",
-			want:   "github.com/arbourd/git-get",
+		"ssh protocol": {
+			remote: "git@github.com:arbourd/git-get.git",
+			want:   "ssh://git@github.com/arbourd/git-get.git",
 		},
-		"filepath": {
-			remote: "github.com///arbourd/git-get",
-			want:   "github.com/arbourd/git-get",
-		},
-		"gitlab subgroups": {
-			remote: "gitlab.com/gitlab-org/dev-subdepartment/ai-experimentation-chrome-plugin",
-			want:   "gitlab.com/gitlab-org/dev-subdepartment/ai-experimentation-chrome-plugin",
+		"no protocol": {
+			remote: "github.com/arbourd/git-get",
+			want:   "https://github.com/arbourd/git-get",
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			remote := clean(c.remote)
-			if remote != c.want {
-				t.Fatalf("unexpected cleaned string:\n\t(GOT): %#v\n\t(WNT): %#v", remote, c.want)
+			url, _ := ParseURL(c.remote)
+			if url.String() != c.want {
+				t.Fatalf("unexpected parsed url string:\n\t(GOT): %#v\n\t(WNT): %#v", url.String(), c.want)
+			}
+		})
+	}
+}
+
+func TestParseDirectory(t *testing.T) {
+	cases := map[string]struct {
+		url  *url.URL
+		want string
+	}{
+		"https protocol": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "arbourd/git-get",
+			},
+			want: "github.com/arbourd/git-get",
+		},
+		"ssh protocol": {
+			url: &url.URL{
+				Scheme: "ssh",
+				Host:   "github.com",
+				Path:   "arbourd/git-get",
+			},
+			want: "github.com/arbourd/git-get",
+		},
+		".git removal": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "arbourd/git-get.git",
+			},
+			want: "github.com/arbourd/git-get",
+		},
+		"multiple slashes": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "arbourd///git-get",
+			},
+			want: "github.com/arbourd/git-get",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := ParseDirectory(c.url)
+			if dir != filepath.Clean(c.want) {
+				t.Fatalf("unexpected parsed directory string:\n\t(GOT): %#v\n\t(WNT): %#v", dir, filepath.Clean(c.want))
 			}
 		})
 	}
@@ -86,31 +132,56 @@ func TestDownload(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cases := map[string]struct {
-		remote string
-		want   string
-		err    bool
+		url  *url.URL
+		want string
+		err  bool
 	}{
-		"github clone": {
-			remote: "github.com/arbourd/git-get",
-			want:   filepath.Join(dir, "github.com/arbourd/git-get"),
+		"clone github": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "arbourd/git-get",
+			},
+			want: filepath.Join(dir, "github.com/arbourd/git-get"),
 		},
-		"gitlab clone": {
-			remote: "gitlab.com/gitlab-org/dev-subdepartment/ai-experimentation-chrome-plugin",
-			want:   filepath.Join(dir, "gitlab.com/gitlab-org/dev-subdepartment/ai-experimentation-chrome-plugin"),
+		"clone ssh github": {
+			url: &url.URL{
+				Scheme: "ssh",
+				User:   url.User("git"),
+				Host:   "github.com",
+				Path:   "arbourd/git-get.git",
+			},
+			want: filepath.Join(dir, "github.com/arbourd/git-get"),
 		},
-		"invalid remote": {
-			remote: "https://github.com////arbourd/git-get",
-			err:    true,
+		"clone gitlab subgroups": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "gitlab.com",
+				Path:   "gitlab-org/dev-subdepartment/ai-experimentation-chrome-plugin",
+			},
+			want: filepath.Join(dir, "gitlab.com/gitlab-org/dev-subdepartment/ai-experimentation-chrome-plugin"),
 		},
-		"not found remote": {
-			remote: "github.com/arbourd/definitely-doesnt-exist",
-			err:    true,
+		"invalid url": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "///arbourd/git-get",
+			},
+			err: true,
+		},
+		"not found": {
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "definitely-doesnt-exist",
+			},
+			err: true,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			path, err := download(dir, c.remote)
+			path, err := Download(c.url, c.want)
 
 			if err != nil && !c.err {
 				t.Fatalf("unexpected error:\n\t(GOT): %#v\n\t(WNT): nil", err)


### PR DESCRIPTION
0.4.0 moved away from the `vcs` pkg which fixed issues with Gitlab
subgoups but removed ssh and other protocol support.

This commit returns support for all other protocols and schemes. If a
protocol or scheme are not provided HTTPS will be used as default.
