### PR TITLE
Run GoReleaser on pull-requests and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,9 @@ jobs:
       - run: go build .
       - run: ./git-get github.com/arbourd/git-get
 
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+  bin:
     needs: [test]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -45,12 +44,20 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
+      - run: go mod download
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --clean
+          install-only: true
+
+      - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: goreleaser release --clean --snapshot
+
+      # Release binaries on release tags
+      - if: startsWith(github.ref, 'refs/tags/v')
+        run: goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
To ensure that the GoReleaser configuration is correct, run the binary
build on every pull-request and commit, but only actually release on
tags.
