### PR TITLE
Add Git config support for configuring GITPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 
 ## Usage
 
-Set a `GITGET_GETPATH` or use the default of `~/src`.
+Set a `GETPATH` or use the default of `~/src`.
 
 ```shell
-export GITGET_GETPATH=~/src
+export GETPATH=~/src
 ```
 
 Get a repository.
 
 ```console
 $ git get github.com/arbourd/git-get
+~/src/github.com/arbourd/git-get
+
+$ git get https://github.com/arbourd/git-get.git
 ~/src/github.com/arbourd/git-get
 
 $ git get git@github.com:arbourd/git-get.git

--- a/main.go
+++ b/main.go
@@ -9,32 +9,32 @@ import (
 )
 
 func main() {
+	dir, err := run()
+	if err != nil {
+		fmt.Printf("error: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(dir)
+}
+
+func run() (string, error) {
 	path, err := get.Path()
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
-		os.Exit(1)
+		return "", err
 	}
 
 	args := os.Args[1:]
 	if len(args) == 0 {
-		fmt.Println("Error: must provide a git repository url")
-		os.Exit(1)
+		return "", fmt.Errorf("must provide a git repository url")
 	}
 	remote := args[0]
 
 	url, err := get.ParseURL(remote)
 	if err != nil {
-		fmt.Printf("Error: unable to parse repository url: \"%s\"\n", remote)
-		os.Exit(1)
+		return "", fmt.Errorf("unable to parse repository url: \"%s\"", remote)
 	}
 
 	dir := filepath.Join(path, get.Directory(url))
-
-	resp, err := get.Clone(url, dir)
-	if err != nil {
-		fmt.Printf("Error: %s\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Println(resp)
+	return get.Clone(url, dir)
 }


### PR DESCRIPTION
Adds a Git config option, `get.path` for managing the location of the GETPATH. The Git config option is preferred over the environmental variable $GETPATH.

It can be set by running `git --global config get.path <path>` and will appear in the global Git config as:

```ini
[get]
  path = <path>
```
