### PR TITLE
Improve tests by using temporary Git config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
+      - run: git config url.https://github.com/.insteadOf ssh://git@github.com/
 
       - uses: actions/setup-go@v5
         with:

--- a/README.md
+++ b/README.md
@@ -4,19 +4,7 @@
 
 ## Usage
 
-Set a `GETPATH` with `git config` or use the default of `~/src`
-
-```console
-$ git config --global get.path "~/src"
-```
-
-The environmental variable `$GETPATH` may also be set:
-
-```shell
-export GETPATH=~/src
-```
-
-Get a repository.
+Get a repository to `~/src`
 
 ```console
 $ git get github.com/arbourd/git-get
@@ -27,6 +15,18 @@ $ git get https://github.com/arbourd/git-get.git
 
 $ git get git@github.com:arbourd/git-get.git
 ~/src/github.com/arbourd/git-get
+```
+
+Set a custom `GETPATH` with `git config`.
+
+```console
+$ git config --global get.path "~/dev"
+```
+
+Set a custom `GETPATH` with the environmental variable `$GETPATH`.
+
+```shell
+export GETPATH=~/dev
 ```
 
 ### Using SSH as the default

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/arbourd/git-get
 
 go 1.22
 
-require (
-	github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0
-	github.com/mitchellh/go-homedir v1.1.0
-)
+require github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0 h1:o5QIusOiH9phm1gY2UGO6JQjYSPFYbgFCcntOigBvMg=
 github.com/ldez/go-git-cmd-wrapper/v2 v2.6.0/go.mod h1:whnaSah+AmezZS8vwp8FyFzEBHZCLKywWILUj5D8Jq0=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
Adds a test fixture that generates a .gitconfig file within a temporary folder for each test. This ensures that the user running the test doesn't have their global Git config changed under them.

Also removes `go-homedir` in favour of stdlib.
