### PR TITLE
Allow variable expansion

### DIFF
--- a/get/get.go
+++ b/get/get.go
@@ -40,6 +40,7 @@ func Path() (string, error) {
 
 		p = filepath.Join(dir, p[1:])
 	}
+	p = os.ExpandEnv(p)
 
 	if !filepath.IsAbs(p) {
 		return "", fmt.Errorf("GETPATH is not an absolute path: \"%s\"", p)

--- a/get/get_test.go
+++ b/get/get_test.go
@@ -26,6 +26,12 @@ func TestPath(t *testing.T) {
 		t.Fatalf("unable to setup test fixture: %s", err)
 	}
 
+	homeVar := "HOME"
+	if runtime.GOOS == "windows" {
+		homeVar = "USERPROFILE"
+	}
+	getpathWithVar := filepath.FromSlash(fmt.Sprintf("$%s/src", homeVar))
+
 	cases := map[string]struct {
 		gitConfigGetpath string
 		envGetpath       string
@@ -39,9 +45,17 @@ func TestPath(t *testing.T) {
 			gitConfigGetpath: configGetpath,
 			expectedPath:     configGetpath,
 		},
+		"git config getpath with variable": {
+			gitConfigGetpath: getpathWithVar,
+			expectedPath:     defaultGetpath,
+		},
 		"env var getpath": {
 			envGetpath:   envGetpath,
 			expectedPath: envGetpath,
+		},
+		"env var getpath with variable": {
+			gitConfigGetpath: getpathWithVar,
+			expectedPath:     defaultGetpath,
 		},
 		"git config getpath overrides env var getpath": {
 			gitConfigGetpath: configGetpath,


### PR DESCRIPTION
Allow the GETPATH to contain and then expand environmental variables.
This allows a user to set `$GOPATH/src` as their GETPATH.
