### PR TITLE
Improve path expansion, tests

### DIFF
--- a/get/get.go
+++ b/get/get.go
@@ -44,7 +44,7 @@ func AbsolutePath() (string, error) {
 	}
 
 	p = os.ExpandEnv(p)
-	if strings.HasPrefix(p, "~") {
+	if p == "~" || strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~"+string(filepath.Separator)) {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("detecting home directory: %w", err)

--- a/get/get.go
+++ b/get/get.go
@@ -120,8 +120,10 @@ func Clone(u *url.URL, dir string) (string, error) {
 		return dir, nil
 	}
 
-	if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
+	if _, statErr := os.Stat(dir); statErr == nil {
 		return "", fmt.Errorf("%s exists but %s does not", dir, filepath.Join(dir, ".git"))
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		return "", fmt.Errorf("checking directory: %w", statErr)
 	}
 
 	// Check if git remote exists before creating any directories

--- a/get/get.go
+++ b/get/get.go
@@ -1,7 +1,9 @@
 package get
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -114,7 +116,15 @@ func Directory(u *url.URL) (string, error) {
 
 // Clone clones the remote repository to the GETPATH and returns the directory
 func Clone(u *url.URL, dir string) (string, error) {
-	// Check if git remote exists
+	if isGitRepository(dir) {
+		return dir, nil
+	}
+
+	if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("%s exists but %s does not", dir, filepath.Join(dir, ".git"))
+	}
+
+	// Check if git remote exists before creating any directories
 	_, err := git.Raw("ls-remote", func(g *types.Cmd) {
 		g.AddOptions(u.String())
 	})
@@ -125,21 +135,12 @@ func Clone(u *url.URL, dir string) (string, error) {
 	}
 
 	parentdir, _ := filepath.Split(dir)
+	if err := os.MkdirAll(parentdir, 0755); err != nil {
+		return "", fmt.Errorf("creating clone directory: %w", err)
+	}
 
-	if !isGitRepository(dir) {
-		if _, err := os.Stat(dir); !os.IsNotExist(err) {
-			return "", fmt.Errorf("%s exists but %s does not", dir, filepath.Join(dir, ".git"))
-		}
-
-		err := os.MkdirAll(parentdir, 0755)
-		if err != nil {
-			return "", fmt.Errorf("creating clone directory: %w", err)
-		}
-
-		_, err = git.Clone(clone.Repository(u.String()), clone.Directory(dir))
-		if err != nil {
-			return "", fmt.Errorf("git clone: %w", err)
-		}
+	if _, err = git.Clone(clone.Repository(u.String()), clone.Directory(dir)); err != nil {
+		return "", fmt.Errorf("git clone: %w", err)
 	}
 
 	return dir, nil

--- a/get/get_test.go
+++ b/get/get_test.go
@@ -66,6 +66,10 @@ func TestAbsolutePath(t *testing.T) {
 			envGetpath: "../test",
 			wantErr:    true,
 		},
+		"tilde-user GETPATH": {
+			envGetpath: "~otheruser/src",
+			wantErr:    true,
+		},
 	}
 
 	for name, c := range cases {

--- a/get/get_test.go
+++ b/get/get_test.go
@@ -227,6 +227,9 @@ func TestDirectory(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network test")
+	}
 	dir := t.TempDir()
 
 	cases := map[string]struct {

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func run(args []string, stdout io.Writer) error {
 		fmt.Fprintln(stdout, Version)
 		return nil
 	case "--complete":
+		// Internal protocol used by shell completion scripts (completions/); not a user-facing flag.
 		prefix := ""
 		if len(args) > 1 {
 			prefix = args[1]


### PR DESCRIPTION
- **Avoid ls-remote call when repo is already cloned**
- **Skip network TestClone when -short is set**
- **Restrict tilde expansion to ~/ in AbsolutePath**
- **Document --complete as an internal shell completion**
- **Fix misleading error when os.Stat fails in Clone**
